### PR TITLE
LIBITD-706. Modified Vagrant configuration for "dummy" SSL cert chain

### DIFF
--- a/vm-sp/files/env
+++ b/vm-sp/files/env
@@ -6,6 +6,7 @@ export SERVER_NAME=192.168.33.20
 export SERVICE_USER=vagrant
 export SERVICE_GROUP=vagrant
 export SSL_CERT_NAME=borrowlocal.crt
+export SSL_CERT_CHAIN_FILE_NAME=DummyCertChain.crt
 export SSL_KEY_NAME=borrowlocal.key
 export RAILS_ENV=development
 
@@ -13,3 +14,10 @@ export RAILS_ENV=development
 export SP_ENTITY_ID=https://192.168.33.20/shibboleth
 export SP_METADATA_URI=http://192.168.33.10/idp/profile/Metadata/SAML
 export SP_METADATA_FILE=federation-metadata.xml
+
+# If a user attempts to go to the "attributes" page directly,
+# Shibboleth attempts to redirect them to a Discovery Service (DS).
+# Since we are not running a discovery service, the SP_DS_REDIRECT_URL
+# parameter specifies where to redirect the user (typically the application
+# home page), instead of showing an error page.
+export SP_DS_REDIRECT_URL=https://192.168.33.20/

--- a/vm-sp/scripts/https-cert.sh
+++ b/vm-sp/scripts/https-cert.sh
@@ -13,6 +13,7 @@ else
     CSR=/apps/ssl/csr/borrowlocal.csr
     CRT=/apps/ssl/cert/borrowlocal.crt
     CNF=/apps/ssl/cnf/borrowlocal.cnf
+    CHAIN=/apps/ssl/cert/DummyCertChain.crt
 
     cat > "$CNF" <<END
 [ req ]
@@ -47,6 +48,15 @@ END
     openssl x509 -req -days 365 -in "$CSR" -signkey "$KEY" -out "$CRT" \
         -extensions v3_req -extfile "$CNF"
 
+    # Create a "dummy" certificate chain file. This is needed because we need
+    # to specify a chain file as part of the Apache configuration, and the file
+    # must exist and be non-empty. It doesn't check if the file it a valid SSL
+    # certificate, though, so we can use anything.
+    cat > "$CHAIN" << END
+Dummy certificate chain file
+END
+
     # cache the SSL cert info for the next run of Vagrant
     cp -rp /apps/ssl /apps/dist
+    
 fi


### PR DESCRIPTION
The dummy SSL certificate chain file is created in
vm-sp/scripts/https-cert.sh.

The vm-sp/files/env file was modified to use the dummy SSL certificate
chain file.

Also added "SP_DS_REDIRECT_URL" needed for LIBITD-680

https://issues.umd.edu/browse/LIBITD-706